### PR TITLE
feat: add custom error classes for flag operations

### DIFF
--- a/.github/instructions/create errors.instructions.md
+++ b/.github/instructions/create errors.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo: "src/common/errors/**"
+---
+
+# Instrucciones para crear nuevos errores personalizados
+
+1. **Ubicación:**  
+   Cada nuevo error debe ser un archivo independiente dentro de la carpeta `src/common/errors/`.
+
+2. **Herencia:**  
+   Todos los errores personalizados deben heredar de la clase `FlagsError` definida en `src/common/errors/flags.error.ts`.
+
+3. **Nombre descriptivo:**  
+   El nombre de la clase de error y del archivo debe describir claramente el propósito del error. Ejemplo:
+
+   - Archivo: `invalid-flag.error.ts`
+   - Clase: `InvalidFlagError`
+
+4. **Estructura mínima del archivo:**  
+   El archivo debe exportar la clase de error como `export class NombreError extends FlagsError { ... }`.
+
+5. **Constructor:**  
+   El constructor debe aceptar un mensaje descriptivo y pasarlo al constructor de `FlagsError`.
+
+6. **Ejemplo:**
+
+```typescript
+// src/common/errors/invalid-flag.error.ts
+import { FlagsError } from "./flags.error.js";
+
+export class InvalidFlagError extends FlagsError {
+  name = "InvalidFlagError";
+  constructor(flagName: string) {
+    super(`...`);
+  }
+}
+```
+
+7. **Exportación:**  
+   Si tienes un archivo de barril (index.ts), recuerda exportar el nuevo error desde allí.

--- a/flags.ts
+++ b/flags.ts
@@ -1,4 +1,5 @@
 import { render, componentModules } from "@jondotsoy/console-draw";
+export { FlagsError } from "./src/common/errors/flags.error.js";
 import { UnknownArgumentError } from "./src/common/errors/unknown-argument.error.js";
 
 const h = componentModules.createElement.bind(componentModules);

--- a/flags.ts
+++ b/flags.ts
@@ -1,4 +1,5 @@
 import { render, componentModules } from "@jondotsoy/console-draw";
+import { UnknownArgumentError } from "./src/common/errors/unknown-argument.error.js";
 
 const h = componentModules.createElement.bind(componentModules);
 
@@ -239,7 +240,7 @@ export const flags = <T>(
     const rule = parses.find(([test]) => {
       return test(ctx.arg, ctx);
     });
-    if (!rule) throw new Error(`Unknown argument: ${arg}`);
+    if (!rule) throw new UnknownArgumentError(arg);
     const [, handler] = rule;
     handler(ctx);
     index = ctx.nextIndex;

--- a/src/common/errors/flags.error.ts
+++ b/src/common/errors/flags.error.ts
@@ -1,0 +1,12 @@
+/**
+ * Represents a custom error specific to flag-related operations within the application.
+ * Extends the built-in `Error` class and sets the error name to `"FlagsError"`.
+ *
+ * @example
+ * ```typescript
+ * throw new FlagsError("Invalid flag value");
+ * ```
+ */
+export class FlagsError extends Error {
+  name = "FlagsError";
+}

--- a/src/common/errors/unknown-argument.error.ts
+++ b/src/common/errors/unknown-argument.error.ts
@@ -1,0 +1,15 @@
+import { FlagsError } from "./flags.error.js";
+
+/**
+ * Error thrown when an unknown argument is encountered while parsing flags.
+ *
+ * @extends FlagsError
+ * @example
+ * throw new UnknownArgumentError('--invalidFlag');
+ */
+export class UnknownArgumentError extends FlagsError {
+  name = "UnknownArgumentError";
+  constructor(arg: string) {
+    super(`Unknown argument: ${arg}`);
+  }
+}


### PR DESCRIPTION
This pull request introduces a structured approach to handling custom errors in the application, specifically related to flag operations. The key changes include the creation of a base error class, `FlagsError`, the addition of specific error types like `UnknownArgumentError`, and updates to the flag parsing logic to use these new error classes. Documentation has also been added to guide the creation of future custom errors.

### New Custom Error System:

* **Base Error Class:**
  - Added `FlagsError` in `src/common/errors/flags.error.ts` as the base class for all flag-related errors. It extends the built-in `Error` class and sets a default error name.

* **Specific Error Implementation:**
  - Created `UnknownArgumentError` in `src/common/errors/unknown-argument.error.ts`, inheriting from `FlagsError`. This error is thrown when an unknown argument is encountered during flag parsing.

### Integration with Flag Parsing:

* **Flag Parsing Logic Update:**
  - Updated the `flags.ts` file to replace generic error throwing with `UnknownArgumentError` when an unknown argument is encountered.

* **Exports:**
  - Exported the `FlagsError` class from `flags.ts` for broader usage.

### Documentation:

* **Error Creation Instructions:**
  - Added `create errors.instructions.md` to provide clear guidelines for creating new error classes, including naming conventions, inheritance requirements, and code structure.